### PR TITLE
added infoWindow capabilities

### DIFF
--- a/Annotation/GeographicalInfoWindow.php
+++ b/Annotation/GeographicalInfoWindow.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Vich\GeographicalBundle\Annotation;
+
+/**
+ * GeographicalQuery.
+ * 
+ * @Annotation
+ * 
+ * @author Dustin Dobervich <ddobervich@gmail.com>
+ */
+class GeographicalInfoWindow
+{
+    /**
+     * @var string $method
+     */
+    private $method;
+    
+    /**
+     * Gets the method name.
+     * 
+     * @return string The method name
+     */
+    public function getMethod()
+    {
+        return $this->method;
+    }
+    
+    /**
+     * Sets the method name.
+     * 
+     * @param string $value The method name
+     */
+    public function setMethod($value)
+    {
+        $this->method = $value;
+    }
+    
+    /**
+     * Constructs a new instance of GeographicalQuery.
+     * 
+     * @param array $values The option values
+     */
+    public function __construct(array $values) {
+        
+    }
+}

--- a/Driver/AnnotationDriver.php
+++ b/Driver/AnnotationDriver.php
@@ -44,6 +44,23 @@ class AnnotationDriver
 
         return $this->reader->getClassAnnotation($geoClass, 'Vich\GeographicalBundle\Annotation\Geographical');    
     }
+
+    public function getGeographicalInfoWindowAnnotation($obj)
+    {
+        if (!is_object($obj)) {
+            throw new \InvalidArgumentException();
+        }
+
+        $refClass = new \ReflectionClass($obj);
+
+        foreach ($refClass->getMethods() as $method) {
+            $annot = $this->reader->getMethodAnnotation($method, 'Vich\GeographicalBundle\Annotation\GeographicalInfoWindow');
+            if ($annot) {
+                $annot->setMethod($method->getName());
+                return $annot;
+            }
+        }
+    }
     
     /**
      * Gets the GeographicalQuery annotation for the specified object.

--- a/Map/MapMarker.php
+++ b/Map/MapMarker.php
@@ -25,7 +25,12 @@ class MapMarker
      * @var string $icon
      */
     private $icon;
-    
+
+    /**
+     * @var string $infoWindow
+     */
+    private $infoWindow;
+
     /**
      * Gets the javascript variable name.
      * 
@@ -84,6 +89,26 @@ class MapMarker
     public function setIcon($value)
     {
         $this->icon = $value;
+    }
+
+    /**
+     * Gets the infoWindow.
+     *
+     * @return string The icon url
+     */
+    public function getInfoWindow()
+    {
+        return $this->infoWindow;
+    }
+
+    /**
+     * Sets the infoWindow.
+     *
+     * @param string $value The icon url
+     */
+    public function setInfoWindow($value)
+    {
+        $this->infoWindow = $value;
     }
     
     /**

--- a/Map/Renderer/GoogleMapRenderer.php
+++ b/Map/Renderer/GoogleMapRenderer.php
@@ -131,7 +131,15 @@ class GoogleMapRenderer extends AbstractMapRenderer
                 $marker->getCoordinate()->getLng(),
                 $map->getVarName()
             );
-            
+
+            $html .= sprintf(
+                'var iw = new google.maps.InfoWindow({
+                content: "%s"}); google.maps.event.addListener(%s, "click", function (e) {iw.open (map, %s); });',
+                $marker->getInfoWindow(),
+                $marker->getVarName(),
+                $marker->getVarName()
+            );
+
             if ($map->getAutoZoom()) {
                 $html .= sprintf(
                     '%s.extend(new google.maps.LatLng(%s, %s));',

--- a/Templating/Helper/MapHelper.php
+++ b/Templating/Helper/MapHelper.php
@@ -94,6 +94,13 @@ class MapHelper extends Helper
             list($lat, $lng) = $this->getLatLng($entity);
             
             $marker = new MapMarker($lat, $lng);
+            $infoWindow = $this->getInfoWindow($entity);
+            if ($infoWindow)
+            {
+                //TODO: get UID from UnitOfWork
+                $marker->setVarName('marker'.$entity->getId());
+                $marker->setInfoWindow($infoWindow);
+            }
             
             $map->addMarker($marker);
         }
@@ -140,5 +147,18 @@ class MapHelper extends Helper
         $lng = $obj->$lngMethod();
         
         return array($lat, $lng);
+    }
+
+    private function getInfoWindow($obj)
+    {
+        $annot = $this->driver->getGeographicalInfoWindowAnnotation($obj);
+        if (!$annot) {
+            //InfoWindow is optional
+            return null;
+        }
+
+        $infoWindowMethod = $annot->getMethod();
+        return $obj->$infoWindowMethod();
+
     }
 }


### PR DESCRIPTION
Hi dustin,

This pull request adds a clickable infoWindow to mapmarkers. http://yfrog.com/kefbmp

infoWindow will be populated with info obtained from the method annotated as @Vich\GeographicalInfoWindow, same way GeographicalQuery works.
If no annotation found, no infoWindow will be displayed.

 /**
- @VIch\GeographicalInfoWindow
  */
  
  public function getGeographicalInfoWindow()
  {
      return 'getGeographicalInfoWindow working...';
  }

TODO: Markers are uniquely named using getId() method from the entity. Find a way to figure out the identifier field of the entity and use it to name them, or simply use an internal variable in the foreach loop. 
MapHeper line 100.

Hope you find it right and merge this PR.
