### PR TITLE
setShowZoomControl() method had a colon instead of semicolon trailing it.

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -403,7 +403,7 @@ class PreConfiguredMap extends Map
         // set some options
         $this->setAutoZoom(true);
         $this->setShowMapTypeControl(true);
-        $this->setShowZoomControl(true):
+        $this->setShowZoomControl(true);
 
         // do something here with the EntityManager to get your entities
 


### PR DESCRIPTION
setShowZoomControl() method had a colon instead of semicolon trailing it. fixed.
