### PR TITLE
probably wrong variable name used by mistake ?

### DIFF
--- a/Adapter/ORM/DoctrineORMAdapter.php
+++ b/Adapter/ORM/DoctrineORMAdapter.php
@@ -28,7 +28,7 @@ class DoctrineORMAdapter implements AdapterInterface
     {
         $obj = $this->getObjectFromArgs($e);
         
-        $em = $args->getEntityManager();
+        $em = $e->getEntityManager();
         $uow = $em->getUnitOfWork();
         $metadata = $em->getClassMetadata(get_class($obj));
         $uow->recomputeSingleEntityChangeSet($metadata, $obj);


### PR DESCRIPTION
getting following error while update:

Fatal error: Call to a member function getEntityManager() on a non-object in /home/foodonline/www/vendor/bundles/Vich/GeographicalBundle/Adapter/ORM/DoctrineORMAdapter.php on line 31

probably typo ?
