### PR TITLE
Update MapProvider.php

### DIFF
--- a/Map/Provider/MapProvider.php
+++ b/Map/Provider/MapProvider.php
@@ -3,6 +3,7 @@
 namespace Vich\GeographicalBundle\Map\Provider;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Vich\GeographicalBundle\Map\Map;
 
 /**
  * MapProvider.
@@ -54,6 +55,10 @@ class MapProvider
      */
     public function getMap($alias)
     {
+        if ($alias instanceof Map) {
+            return $alias;
+        }
+        
         if (!array_key_exists($alias, $this->maps)) {
             $this->loadMap($alias);
         }


### PR DESCRIPTION
You can now use {{ vichgeo_map() }} and {{ vichgeo_map_for() }} using Map instances as argument.
So you can avoid service definitions.
