### PR TITLE
New behaviour in infowindow markers in google maps

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -46,6 +46,12 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('api_key')->defaultNull()->end()
                     ->end()
                 ->end()
+                ->arrayNode('google')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('only_one_info_window')->defaultFalse()->end()
+                    ->end()
+                ->end()
             ->end()
         ;
         

--- a/DependencyInjection/VichGeographicalExtension.php
+++ b/DependencyInjection/VichGeographicalExtension.php
@@ -85,6 +85,10 @@ class VichGeographicalExtension extends Extension
         if (null !== $config['bing']['api_key']) {
             $rendererOptions['bing_api_key'] = $config['bing']['api_key'];
         }
+
+        if (null !== $config['google']['only_one_info_window']) {
+            $rendererOptions['google_only_one_info_window'] = $config['google']['only_one_info_window'];
+        }
         
         $container->setAlias('vich_geographical.query_service', $config['query_service']);
         $container->setAlias('vich_geographical.map_renderer', $config['map_renderer']);

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ own map renderer.
 
 For usage documentation, see:
 
-[Resources/doc/index.md](https://github.com/dustin10/VichGeographicalBundle/blob/master/Resources/doc/index.md)
+[Resources/doc/index.md](https://github.com/jlaso/VichGeographicalBundle/blob/master/Resources/doc/index.md)
     
 
 For license, see:
 
-[Resources/meta/LICENSE](https://github.com/dustin10/VichGeographicalBundle/blob/master/Resources/meta/LICENSE)
+[Resources/meta/LICENSE](https://github.com/jlaso/VichGeographicalBundle/blob/master/Resources/meta/LICENSE)

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -32,6 +32,9 @@ Add VichGeographicalBundle in your `composer.json`:
 
 ```
 {
+    "repositories": [
+        {"type":"vcs", "url":"https://github.com/jlaso/VichGeographicalBundle.git"}
+    ],
     "require": {
         "vich/geographical-bundle": "*"
     }

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -480,10 +480,10 @@ rendered with `vichgeo_map`.
 {{ vichgeo_map('pre_configured') }}
 ```
 
-Popup Info Windows
-==================
+Popup InfoWindows
+=================
 
-The bundle supports popup info windows when map markers are clicked. Use 
+The bundle supports popup infowindows when map markers are clicked. Use 
 the `setShowInfoWindowsForMarkers` setter of the `Map` class to activate or 
 deactivate (default) this feature. A default template for the content of the 
 popup has been provided, but it is strongly recommended that you create a twig/php 

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -266,6 +266,21 @@ vich_geographical:
     query_service: my_custom_service    
 ```
 
+## Overriding the default behaviour of infowindow in Google maps
+
+When the infowindow associated to a marker is opened by the user, the previous window of
+other infowindow opened preiously is not closed
+see https://developers.google.com/maps/documentation/javascript/infowindows#close
+You can change this behaviour using the google.only_one_info_window key in config.yml.
+
+``` yaml
+# app/config.yml
+vich_geographical:
+    # ...
+    google:
+        only_one_info_window: true
+```
+
 Twig Integration
 ================
 
@@ -531,4 +546,9 @@ vich_geographical:
     # if you specify the Bing map renderer then add your api key as follows
     bing:
         api_key: my_api_key
+
+    # if you specify the Google map renderer you can allow only one infowindow open for all markers in the map
+    # the default value is false, i.e. all the infowindow open for each marker have to be closed by visitor
+    google:
+        only_one_info_window: true
 ```

--- a/composer.json
+++ b/composer.json
@@ -1,22 +1,27 @@
 {
-    "name": "vich/geographical-bundle",
+    "name": "jlaso/geographical-bundle",
     "type": "symfony-bundle",
     "description": "Geographical functionality for ORM and ODM entities and JavaScript maps rendering",
     "keywords": ["maps", "geographical", "annotations", "google", "bing", "annotations"],
-    "homepage": "https://github.com/dustin10/VichGeographicalBundle",
+    "homepage": "https://github.com/jlaso/VichGeographicalBundle",
     "license": "MIT",
     "authors": [
         {
             "name": "Dustin Dobervich",
             "email": "ddobervich@gmail.com",
             "homepage": "http://www.dobervich.com"
+        },
+        {
+            "name": "Joseluis Laso",
+            "email": "jlaso@joseluislaso.es",
+            "homepage": "http://www.joseluislaso.es"
         }
     ],
     "require": {
         "php": ">=5.3.2"
     },
     "autoload": {
-        "psr-0": { "Vich\\GeographicalBundle": "" }
+        "psr-0": { "JLaso\\GeographicalBundle": "" }
     },
-    "target-dir": "Vich/GeographicalBundle"
+    "target-dir": "JLaso/GeographicalBundle"
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "jlaso/geographical-bundle",
+    "name": "vich/geographical-bundle",
     "type": "symfony-bundle",
     "description": "Geographical functionality for ORM and ODM entities and JavaScript maps rendering",
     "keywords": ["maps", "geographical", "annotations", "google", "bing", "annotations"],

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": ">=5.3.2"
     },
     "autoload": {
-        "psr-0": { "JLaso\\GeographicalBundle": "" }
+        "psr-0": { "Vich\\GeographicalBundle": "" }
     },
-    "target-dir": "JLaso/GeographicalBundle"
+    "target-dir": "Vich/GeographicalBundle"
 }


### PR DESCRIPTION
- added new key in config in order to restrict to one the markers' infowindow opened in a google map
  The default behaviour of an infowindow of a marker is that have to closed by the visitor.
  To allow bypassing this behaviour I just created a new config key.
  In the rendered the logic needed to close the last infowindow is added automatically. 
